### PR TITLE
Proxy dismissViewControllerAnimated through CompatibleAlertController

### DIFF
--- a/PRCompatibleAlertController/PRCompatibleAlertController/CompatibleAlertController/CompatibleAlertController.h
+++ b/PRCompatibleAlertController/PRCompatibleAlertController/CompatibleAlertController/CompatibleAlertController.h
@@ -48,6 +48,9 @@ typedef void (^CompatibleAlertActionHandler)(CompatibleAlertAction*);
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *message;
 
+- (void)dismissViewControllerAnimated:(BOOL)flag
+                           completion:(void (^)(void))completion;
+
 - (void)addAction:(CompatibleAlertAction *)action;
 @property (nonatomic, readonly) NSMutableArray *actions;
 

--- a/PRCompatibleAlertController/PRCompatibleAlertController/CompatibleAlertController/CompatibleAlertController.m
+++ b/PRCompatibleAlertController/PRCompatibleAlertController/CompatibleAlertController/CompatibleAlertController.m
@@ -113,6 +113,15 @@
     }
 }
 
+- (void)dismissViewControllerAnimated:(BOOL)flag
+                           completion:(void (^)(void))completion{
+
+    [self dismissViewControllerAnimated:flag completion:completion]
+    
+
+}
+
+
 - (void)addAction:(CompatibleAlertAction *)action{
     [self.actions addObject:action];
 }


### PR DESCRIPTION
the function dismissViewControllerAnimated was missing for the CompatibleAlertController, but it seems it just can be proxied through.
